### PR TITLE
Engine graceful shutdown

### DIFF
--- a/GAME/include/GAME/AppEntryPoint.hpp
+++ b/GAME/include/GAME/AppEntryPoint.hpp
@@ -2,7 +2,6 @@
 #define GAME_APPENTRYPOINT_HPP
 
 #include <SOGE/SOGE.hpp>
-#include <SOGE/Core/EntryPoint.hpp>
 
 
 namespace game

--- a/GAME/source/GAME/AppEntryPoint.cpp
+++ b/GAME/source/GAME/AppEntryPoint.cpp
@@ -1,5 +1,7 @@
 #include "GAME/AppEntryPoint.hpp"
 
+#include <SOGE/Core/EntryPoint.hpp>
+
 
 namespace game
 {

--- a/SOGE/include/SOGE/Core/Engine.hpp
+++ b/SOGE/include/SOGE/Core/Engine.hpp
@@ -15,14 +15,13 @@ namespace soge
     {
     private:
         static UniquePtr<Engine> s_instance;
-        static std::mutex s_initMutex;
+        static std::mutex s_mutex;
 
         bool m_isRunning;
+        bool m_shutdownRequested;
 
     protected:
         explicit Engine();
-
-        void Shutdown();
 
     public:
         Engine(const Engine&) = delete;
@@ -38,9 +37,10 @@ namespace soge
         template <DerivedFromEngine T = Engine, typename... Args>
         static T* Reset(Args&&... args);
 
+        [[nodiscard]]
+        bool IsRunning() const;
+
         void Run();
-        void Update();
-        void FixedUpdate();
         void RequestShutdown();
     };
 
@@ -54,7 +54,7 @@ namespace soge
 
         // Acquire lock just before moving the new instance
         // (this allows to allocate new instance in parallel compared to acquiring at the beginning of the function)
-        std::lock_guard lock(s_initMutex);
+        std::lock_guard lock(s_mutex);
         // Move new instance to the static instance
         s_instance = std::move(newInstance);
         // Return previously saved pointer

--- a/SOGE/include/SOGE/Core/EntryPoint.hpp
+++ b/SOGE/include/SOGE/Core/EntryPoint.hpp
@@ -57,7 +57,8 @@ inline bool soge::ConsoleInit(Span<char*> args)
             // Ctrl+C or Ctrl+Break events are not terminating the program, but close event does
             // https://learn.microsoft.com/en-us/windows/console/handlerroutine
             const bool shouldYield = aCtrlType == CTRL_CLOSE_EVENT;
-            while (shouldYield) // NOLINT(bugprone-infinite-loop)
+            // NOLINTNEXTLINE(bugprone-infinite-loop) reason: intended behaviour
+            while (shouldYield)
             {
                 // Allow for other threads (such as the main thread) to finish their work
                 // This should work because Windows calls this handler in a separate thread

--- a/SOGE/include/SOGE/Core/EntryPoint.hpp
+++ b/SOGE/include/SOGE/Core/EntryPoint.hpp
@@ -1,8 +1,9 @@
 #ifndef SOGE_CORE_ENTRYPOINT_HPP
 #define SOGE_CORE_ENTRYPOINT_HPP
 
-#include "SOGE/System/Memory.hpp"
 #include "SOGE/Utils/Logger.hpp"
+
+#include <span>
 
 
 namespace soge
@@ -10,10 +11,10 @@ namespace soge
     extern Engine* CreateApplication();
 
     [[nodiscard]]
-    bool ConsoleInit(Span<char*> args);
+    bool ConsoleInit(std::span<char*> args);
 
     [[nodiscard]]
-    inline int Launch(const Span<char*> args)
+    inline int Launch(const std::span<char*> args)
     {
         if (!ConsoleInit(args))
         {
@@ -33,7 +34,7 @@ namespace soge
 
 #include <Windows.h>
 
-inline bool soge::ConsoleInit(Span<char*> args)
+inline bool soge::ConsoleInit(std::span<char*> args)
 {
 #ifdef SOGE_DEBUG
     // By using console ctrl handler, we can gracefully shut down the engine
@@ -90,13 +91,13 @@ inline int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR l
 {
     using namespace soge;
 
-    const Span args{__argv, static_cast<USize>(__argc)};
+    const std::span args{__argv, static_cast<std::size_t>(__argc)};
     return Launch(args);
 }
 
 #else
 
-inline bool soge::ConsoleInit(Span<char*> args)
+inline bool soge::ConsoleInit(std::span<char*> args)
 {
     return true;
 }
@@ -105,7 +106,7 @@ inline int main(int argc, char** argv)
 {
     using namespace soge;
 
-    const Span args{argv, static_cast<USize>(argc)};
+    const std::span args{argv, static_cast<std::size_t>(argc)};
     return Launch(args);
 }
 

--- a/SOGE/include/SOGE/Core/EntryPoint.hpp
+++ b/SOGE/include/SOGE/Core/EntryPoint.hpp
@@ -1,44 +1,106 @@
 #ifndef SOGE_CORE_ENTRYPOINT_HPP
 #define SOGE_CORE_ENTRYPOINT_HPP
 
+#include "SOGE/System/Memory.hpp"
 #include "SOGE/Utils/Logger.hpp"
 
 
-extern soge::Engine* soge::CreateApplication();
+namespace soge
+{
+    extern Engine* CreateApplication();
+
+    [[nodiscard]]
+    bool ConsoleInit(Span<char*> args);
+
+    [[nodiscard]]
+    inline int Launch(const Span<char*> args)
+    {
+        if (!ConsoleInit(args))
+        {
+            return EXIT_FAILURE;
+        }
+
+        Logger::Init();
+
+        const auto app = CreateApplication();
+        app->Run();
+
+        return EXIT_SUCCESS;
+    }
+}
 
 #ifdef SOGE_WINDOWS
 
 #include <Windows.h>
 
-int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLine, int nShowCmd)
+inline bool soge::ConsoleInit(Span<char*> args)
 {
-
 #ifdef SOGE_DEBUG
-    AllocConsole();
-    freopen("CONOUT$", "w+", stdout);
+    // By using console ctrl handler, we can gracefully shut down the engine
+
+    // Hack to define local handler function
+    struct CtrlHandler
+    {
+        // Prevent opened console from closing before the engine has finished shutting down
+        // https://stackoverflow.com/questions/3640633/setconsolectrlhandler-routine-issue
+        static BOOL WINAPI Handle(DWORD aCtrlType)
+        {
+            // Wait for the engine to gracefully shutdown
+            if (const auto engine = Engine::GetInstance())
+            {
+                engine->RequestShutdown();
+                while (engine->IsRunning())
+                {
+                }
+            }
+
+            // Maximum amount of time to wait until main thread exits
+            std::this_thread::sleep_for(std::chrono::seconds(10));
+            return TRUE;
+        }
+    };
+
+    if (!AllocConsole() || !SetConsoleCtrlHandler(CtrlHandler::Handle, TRUE))
+    {
+        SOGE_ERROR_LOG("Failed to initialize console");
+        return false;
+    }
+
+    FILE* unusedStream;
+    if (freopen_s(&unusedStream, "CONOUT$", "w+", stdout) != 0)
+    {
+        SOGE_ERROR_LOG("Failed to reopen stdout");
+        return false;
+    }
+
 #endif // SOGE_DEBUG
 
-    soge::Logger::Init();
+    return true;
+}
 
-    const auto app = soge::CreateApplication();
-    app->Run();
-    delete app;
+inline int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLine, int nShowCmd)
+{
+    using namespace soge;
 
-    return 0;
+    const Span args{__argv, static_cast<USize>(__argc)};
+    return Launch(args);
 }
 
 #else
 
-int main(int argc, char** argv)
+inline bool soge::ConsoleInit(Span<char*> args)
 {
-    soge::Logger::Init();
+    return true;
+}
 
-    auto app = soge::CreateApplication();
-    app->Run();
-    delete app;
+inline int main(int argc, char** argv)
+{
+    using namespace soge;
 
-    return 0;
+    const Span args{argv, static_cast<USize>(argc)};
+    return Launch(args);
 }
 
 #endif // SOGE_WINDOWS
+
 #endif // SOGE_CORE_ENTRYPOINT_HPP

--- a/SOGE/include/SOGE/System/Memory.hpp
+++ b/SOGE/include/SOGE/System/Memory.hpp
@@ -2,18 +2,11 @@
 #define SOGE_SYSTEM_MEMORY_HPP
 
 #include <EASTL/shared_ptr.h>
-#include <EASTL/span.h>
 #include <EASTL/unique_ptr.h>
 
 
 namespace soge
 {
-    using size_t = eastl_size_t;
-    using USize = size_t;
-
-    using ssize_t = eastl_ssize_t;
-    using ISize = ssize_t;
-
     template <typename T>
     using SharedPtr = eastl::shared_ptr<T>;
 
@@ -31,9 +24,6 @@ namespace soge
     {
         return eastl::make_unique<T>(std::forward<Args>(args)...);
     }
-
-    template <typename T, std::size_t Extent = eastl::dynamic_extent>
-    using Span = eastl::span<T, Extent>;
 }
 
 #endif // SOGE_SYSTEM_MEMORY_HPP

--- a/SOGE/include/SOGE/System/Memory.hpp
+++ b/SOGE/include/SOGE/System/Memory.hpp
@@ -2,11 +2,18 @@
 #define SOGE_SYSTEM_MEMORY_HPP
 
 #include <EASTL/shared_ptr.h>
+#include <EASTL/span.h>
 #include <EASTL/unique_ptr.h>
 
 
 namespace soge
 {
+    using size_t = eastl_size_t;
+    using USize = size_t;
+
+    using ssize_t = eastl_ssize_t;
+    using ISize = ssize_t;
+
     template <typename T>
     using SharedPtr = eastl::shared_ptr<T>;
 
@@ -24,6 +31,9 @@ namespace soge
     {
         return eastl::make_unique<T>(std::forward<Args>(args)...);
     }
+
+    template <typename T, std::size_t Extent = eastl::dynamic_extent>
+    using Span = eastl::span<T, Extent>;
 }
 
 #endif // SOGE_SYSTEM_MEMORY_HPP

--- a/SOGE/include/SOGE/Utils/Logger.hpp
+++ b/SOGE/include/SOGE/Utils/Logger.hpp
@@ -12,7 +12,7 @@ namespace soge
 {
     class Logger final
     {
-        using LoggerPtr = eastl::shared_ptr<spdlog::logger>;
+        using LoggerPtr = std::shared_ptr<spdlog::logger>;
         using LoggerRef = LoggerPtr&;
 
     private:
@@ -45,6 +45,11 @@ namespace soge
     template <typename... Args>
     inline void Logger::EngineLogErrorMessage(Args&&... args)
     {
+        if (s_engineSideLogger == nullptr)
+        {
+            return;
+        }
+
         s_engineSideLogger->error(std::forward<Args>(args)...);
         if (s_isStackTraceOnErrorEnabled)
         {
@@ -55,6 +60,11 @@ namespace soge
     template <typename... Args>
     inline void Logger::EngineLogWarnMessage(Args&&... args)
     {
+        if (s_engineSideLogger == nullptr)
+        {
+            return;
+        }
+
         s_engineSideLogger->warn(std::forward<Args>(args)...);
         if (s_isStackTraceOnWarnEnabled)
         {
@@ -65,6 +75,11 @@ namespace soge
     template <typename... Args>
     inline void Logger::AppLogErrorMessage(Args&&... args)
     {
+        if (s_applicationSideLogger == nullptr)
+        {
+            return;
+        }
+
         s_applicationSideLogger->error(std::forward<Args>(args)...);
         if (s_isStackTraceOnErrorEnabled)
         {
@@ -75,6 +90,11 @@ namespace soge
     template <typename... Args>
     inline void Logger::AppLogWarnMessage(Args&&... args)
     {
+        if (s_applicationSideLogger == nullptr)
+        {
+            return;
+        }
+
         s_applicationSideLogger->warn(std::forward<Args>(args)...);
         if (s_isStackTraceOnWarnEnabled)
         {

--- a/SOGE/source/SOGE/Core/Engine.cpp
+++ b/SOGE/source/SOGE/Core/Engine.cpp
@@ -36,16 +36,6 @@ namespace soge
     Engine::~Engine()
     {
         SOGE_INFO_LOG("Destroy engine...");
-
-#ifdef SOGE_DEBUG
-
-#ifdef SOGE_WINDOWS
-        Beep(500, 1000);
-#else
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-#endif // SOGE_WINDOWS
-
-#endif // SOGE_DEBUG
     }
 
     void Engine::Run()

--- a/SOGE/source/SOGE/Core/Engine.cpp
+++ b/SOGE/source/SOGE/Core/Engine.cpp
@@ -7,7 +7,7 @@
 namespace soge
 {
     UniquePtr<Engine> Engine::s_instance(nullptr);
-    std::mutex Engine::s_initMutex;
+    std::mutex Engine::s_mutex;
 
     Engine* Engine::GetInstance()
     {
@@ -18,7 +18,7 @@ namespace soge
         }
 
         // Safe but slow path: initialize with default class if empty
-        std::lock_guard lock(s_initMutex);
+        std::lock_guard lock(s_mutex);
         // Additional check to ensure we are creating new instance exactly once
         if (s_instance == nullptr)
         {
@@ -28,7 +28,7 @@ namespace soge
         return s_instance.get();
     }
 
-    Engine::Engine() : m_isRunning(false)
+    Engine::Engine() : m_isRunning(false), m_shutdownRequested(false)
     {
         SOGE_INFO_LOG("Initialize engine...");
     }
@@ -36,36 +36,46 @@ namespace soge
     Engine::~Engine()
     {
         SOGE_INFO_LOG("Destroy engine...");
+
+#ifdef SOGE_DEBUG
+
+#ifdef SOGE_WINDOWS
+        Beep(500, 1000);
+#else
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+#endif // SOGE_WINDOWS
+
+#endif // SOGE_DEBUG
     }
 
     void Engine::Run()
     {
+        if (m_isRunning)
+        {
+            return;
+        }
+
+        // Prevent users from resetting engine while it is running
+        std::lock_guard lock(s_mutex);
         m_isRunning = true;
-        while (m_isRunning)
+
+        m_shutdownRequested = false;
+        while (!m_shutdownRequested)
         {
             Timestep::StartFrame();
             Timestep::CalculateDelta();
-
         }
 
-        Shutdown();
+        m_isRunning = false;
     }
 
-    void Engine::Update()
+    bool Engine::IsRunning() const
     {
-        FixedUpdate();
-    }
-
-    void Engine::FixedUpdate()
-    {
+        return m_isRunning;
     }
 
     void Engine::RequestShutdown()
     {
-        m_isRunning = false;
-    }
-
-    void Engine::Shutdown()
-    {
+        m_shutdownRequested = true;
     }
 }

--- a/SOGE/source/SOGE/Utils/Logger.cpp
+++ b/SOGE/source/SOGE/Utils/Logger.cpp
@@ -13,13 +13,12 @@ namespace soge
 
     void Logger::Init()
     {
-
         spdlog::set_pattern("%^[%T] %! [%n %l]: %v%$");
 
-        s_engineSideLogger = LoggerPtr(spdlog::stdout_color_mt("ENGINE").get());
+        s_engineSideLogger = spdlog::stdout_color_mt("ENGINE");
         s_engineSideLogger->set_level(spdlog::level::trace);
 
-        s_applicationSideLogger = LoggerPtr(spdlog::stdout_color_mt("APP").get());
+        s_applicationSideLogger = spdlog::stdout_color_mt("APP");
         s_applicationSideLogger->set_level(spdlog::level::trace);
     }
 
@@ -37,7 +36,7 @@ namespace soge
     {
         if (s_isStackTraceOnErrorEnabled)
         {
-            StackTrace stackTraceInfo;
+            const StackTrace stackTraceInfo;
             s_engineSideLogger->debug(stackTraceInfo.Get());
         }
     }

--- a/SOGE/source/sogepch.cpp
+++ b/SOGE/source/sogepch.cpp
@@ -8,9 +8,8 @@
  * located in global space. Note that pch header may be probably not
  * a very good place to store it.
  **/
-// NOLINTBEGIN(readability-identifier-naming)
+// NOLINTNEXTLINE(readability-identifier-naming) reason: names were taken from declaration
 void* __cdecl operator new[](size_t size, const char* pName, int flags, unsigned debugFlags, const char* file, int line)
-// NOLINTEND(readability-identifier-naming)
 {
     return new uint8_t[size];
 }
@@ -23,10 +22,9 @@ void* __cdecl operator new[](size_t size, const char* pName, int flags, unsigned
  * located in global space. Note that pch header may be probably not
  * a very good place to store it.
  **/
-// NOLINTBEGIN(readability-identifier-naming)
+// NOLINTNEXTLINE(readability-identifier-naming) reason: names were taken from declaration
 void* __cdecl operator new[](size_t size, size_t alignment, size_t alignmentOffset, const char* pName, int flags,
                              unsigned debugFlags, const char* file, int line)
-// NOLINTEND(readability-identifier-naming)
 {
     return new uint8_t[size];
 }


### PR DESCRIPTION
The problem: by opening debug console via `AllocConsole()`, we should handle events from it, or else destructor of game engine will not be called, and used resources will not be freed.

Also during debugging I noticed that logger instances used themselves even after they were destroyed by `eastl::shared_ptr`. I guess this happened because by copying raw pointer from one shared pointer to another, ownership of object were not passed, and 2 separate shared pointers (one from EASTL, other from STL) with reference counter value of 1 existed at the same time: when the first one was destroyed, other tried to use already deleted object.

And so, I handled shutdown events correctly and added beep sound playback in engine destructor (in debug mode only) to ensure destructor will actually be called and info messages about engine shutdown will be visible in the console for a short amount of time.