### PR TITLE
String identifiers

### DIFF
--- a/SOGE/include/SOGE/Core/EntryPoint.hpp
+++ b/SOGE/include/SOGE/Core/EntryPoint.hpp
@@ -25,7 +25,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLin
     using namespace soge::string_id_literals;
 
     auto logStringId = [](const soge::StringId& id) {
-        const auto cStr = id.GetView().data();
+        const auto cStr = id.GetString().data();
         SOGE_INFO_LOG("String identifier with value \"{}\" has hash {} and pointer {}", cStr, id.GetHash(),
                       static_cast<const void*>(cStr));
     };
@@ -36,7 +36,12 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLin
     std::string string = "Hello, World";
     const auto allocatedId = soge::StringId(string);
     logStringId(allocatedId);
-    assert(allocatedId == constId && "StringId should be able to reuse existing strings");
+    assert(allocatedId == constId && "Compile-time and runtime StringIds should be equal");
+
+    const auto reusedId = soge::StringId("Hello, World");
+    logStringId(reusedId);
+    assert(allocatedId.GetString().data() == allocatedId.GetString().data() &&
+           "StringId should be able to reuse existing strings at runtime");
 
     string += "!";
     const auto newId = soge::StringId(string);

--- a/SOGE/include/SOGE/Core/EntryPoint.hpp
+++ b/SOGE/include/SOGE/Core/EntryPoint.hpp
@@ -1,7 +1,6 @@
 #ifndef SOGE_CORE_ENTRYPOINT_HPP
 #define SOGE_CORE_ENTRYPOINT_HPP
 
-#include "SOGE/System/StringId.hpp"
 #include "SOGE/Utils/Logger.hpp"
 
 
@@ -20,33 +19,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLin
 #endif // SOGE_DEBUG
 
     soge::Logger::Init();
-
-    // TODO remove after testing
-    using namespace soge::string_id_literals;
-
-    auto logStringId = [](const soge::StringId& id) {
-        const auto cStr = id.GetString().data();
-        SOGE_INFO_LOG("String identifier with value \"{}\" has hash {} and pointer {}", cStr, id.GetHash(),
-                      static_cast<const void*>(cStr));
-    };
-
-    constexpr auto constId = "Hello, World"_sid;
-    logStringId(constId);
-
-    std::string string = "Hello, World";
-    const auto allocatedId = soge::StringId(string);
-    logStringId(allocatedId);
-    assert(allocatedId == constId && "Compile-time and runtime StringIds should be equal");
-
-    const auto reusedId = soge::StringId("Hello, World");
-    logStringId(reusedId);
-    assert(allocatedId.GetString().data() == allocatedId.GetString().data() &&
-           "StringId should be able to reuse existing strings at runtime");
-
-    string += "!";
-    const auto newId = soge::StringId(string);
-    logStringId(newId);
-    assert(allocatedId != newId && "StringId should not reuse existing strings if they have been modified");
 
     const auto app = soge::CreateApplication();
     app->Run();

--- a/SOGE/include/SOGE/Core/EntryPoint.hpp
+++ b/SOGE/include/SOGE/Core/EntryPoint.hpp
@@ -1,6 +1,7 @@
 #ifndef SOGE_CORE_ENTRYPOINT_HPP
 #define SOGE_CORE_ENTRYPOINT_HPP
 
+#include "SOGE/System/StringId.hpp"
 #include "SOGE/Utils/Logger.hpp"
 
 
@@ -19,6 +20,28 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLin
 #endif // SOGE_DEBUG
 
     soge::Logger::Init();
+
+    // TODO remove after testing
+    using namespace soge::string_id_literals;
+
+    auto logStringId = [](const soge::StringId& id) {
+        const auto cStr = id.GetView().data();
+        SOGE_INFO_LOG("String identifier with value \"{}\" has hash {} and pointer {}", cStr, id.GetHash(),
+                      static_cast<const void*>(cStr));
+    };
+
+    constexpr auto constId = "Hello, World"_sid;
+    logStringId(constId);
+
+    std::string string = "Hello, World";
+    const auto allocatedId = soge::StringId(string);
+    logStringId(allocatedId);
+    assert(allocatedId == constId && "StringId should be able to reuse existing strings");
+
+    string += "!";
+    const auto newId = soge::StringId(string);
+    logStringId(newId);
+    assert(allocatedId != newId && "StringId should not reuse existing strings if they have been modified");
 
     const auto app = soge::CreateApplication();
     app->Run();

--- a/SOGE/include/SOGE/System/StringId.hpp
+++ b/SOGE/include/SOGE/System/StringId.hpp
@@ -16,16 +16,27 @@ namespace soge
 
     private:
         using String = eastl::string;
+        static_assert(eastl::is_same_v<CStr, String::const_pointer>,
+                      "C-string and String must have the same char type");
+
+        // Define separate hasher to use constexpr
+        struct Hasher
+        {
+            constexpr Hash operator()(View aView) const noexcept;
+        };
+
         using Set = eastl::hash_set<String, eastl::hash<String>, eastl::equal_to<String>, EASTLAllocatorType, true>;
         static Set s_set;
+
+        void InitializeAtRuntime(View aView);
 
         Hash m_hash;
         View m_view;
 
     public:
-        explicit StringId(View aView);
-        explicit StringId(CStr aCStr);
-        explicit StringId(std::nullptr_t) = delete;
+        explicit constexpr StringId(View aView);
+        explicit constexpr StringId(CStr aCStr);
+        explicit constexpr StringId(std::nullptr_t) = delete;
 
         explicit constexpr StringId(const StringId&) noexcept = default;
         constexpr StringId& operator=(const StringId&) noexcept = default;
@@ -33,19 +44,77 @@ namespace soge
         explicit constexpr StringId(StringId&&) noexcept = default;
         constexpr StringId& operator=(StringId&&) noexcept = default;
 
-        ~StringId() = default;
+        constexpr ~StringId() noexcept = default;
 
         [[nodiscard]]
-        Hash GetHash() const noexcept;
+        constexpr Hash GetHash() const noexcept;
         [[nodiscard]]
-        View GetView() const noexcept;
+        constexpr View GetView() const noexcept;
 
-        operator View() const noexcept;
-        operator CStr() const noexcept;
+        constexpr operator View() const noexcept;
+        constexpr operator CStr() const noexcept;
 
-        auto operator<=>(const StringId&) const noexcept = default;
-        bool operator==(const StringId&) const noexcept = default;
+        constexpr auto operator<=>(const StringId&) const noexcept = default;
+        constexpr bool operator==(const StringId&) const noexcept = default;
     };
+
+    namespace string_id_literals
+    {
+        constexpr StringId operator""_sid(const StringId::CStr aCStr, const std::size_t aLength)
+        {
+            const StringId::View view{aCStr, aLength};
+            return StringId(view);
+        }
+    }
+
+    // algorithm were taken from EASTL/string_view.h (at line 605)
+    constexpr auto StringId::Hasher::operator()(const View aView) const noexcept -> Hash
+    {
+        View::const_iterator p = aView.cbegin();
+        View::const_iterator end = aView.cend();
+        uint32_t result = 2166136261U; // We implement an FNV-like string hash.
+        while (p != end)
+            result = (result * 16777619) ^ (uint8_t)*p++;
+        return (size_t)result;
+    }
+
+    constexpr StringId::StringId(const View aView)
+    {
+        if (std::is_constant_evaluated())
+        {
+            // TODO decide if we should save this string in the set
+            // (but I guess this is not possible at compile time)
+            m_hash = Hasher{}(aView);
+            m_view = aView;
+            return;
+        }
+
+        InitializeAtRuntime(aView);
+    }
+
+    constexpr StringId::StringId(const CStr aCStr) : StringId(View{aCStr})
+    {
+    }
+
+    constexpr auto StringId::GetHash() const noexcept -> Hash
+    {
+        return m_hash;
+    }
+
+    constexpr auto StringId::GetView() const noexcept -> View
+    {
+        return m_view;
+    }
+
+    constexpr StringId::operator View() const noexcept
+    {
+        return m_view;
+    }
+
+    constexpr StringId::operator CStr() const noexcept
+    {
+        return m_view.data();
+    }
 }
 
 #endif // SOGE_SYSTEM_STRINGID_HPP

--- a/SOGE/include/SOGE/System/StringId.hpp
+++ b/SOGE/include/SOGE/System/StringId.hpp
@@ -19,13 +19,14 @@ namespace soge
         static_assert(eastl::is_same_v<CStr, String::const_pointer>,
                       "C-string and String must have the same base char type");
 
-        // Define separate hasher to use constexpr
         struct Hasher
         {
             constexpr Hash operator()(StrView aView) const noexcept;
+            constexpr Hash operator()(eastl::string_view aView) const noexcept;
+            Hash operator()(const String& aStr) const noexcept;
         };
 
-        using Set = eastl::hash_set<String, eastl::hash<String>, eastl::equal_to<String>, EASTLAllocatorType, true>;
+        using Set = eastl::hash_set<String, Hasher, eastl::equal_to<String>, EASTLAllocatorType, true>;
         static Set s_set;
 
         void InitializeAtRuntime(StrView aView);
@@ -76,6 +77,12 @@ namespace soge
         while (p != end)
             result = (result * 16777619) ^ (uint8_t)*p++;
         return (size_t)result;
+    }
+
+    constexpr auto StringId::Hasher::operator()(const eastl::string_view aView) const noexcept -> Hash
+    {
+        const StrView view{aView.data(), aView.size()};
+        return operator()(view);
     }
 
     constexpr StringId::StringId(const StrView aView)

--- a/SOGE/include/SOGE/System/StringId.hpp
+++ b/SOGE/include/SOGE/System/StringId.hpp
@@ -1,0 +1,51 @@
+#ifndef SOGE_SYSTEM_STRINGID_HPP
+#define SOGE_SYSTEM_STRINGID_HPP
+
+#include <EASTL/hash_set.h>
+#include <EASTL/string.h>
+
+
+namespace soge
+{
+    class StringId final
+    {
+    public:
+        using Hash = eastl_size_t;
+        using View = std::string_view;
+        using CStr = View::const_pointer;
+
+    private:
+        using String = eastl::string;
+        using Set = eastl::hash_set<String, eastl::hash<String>, eastl::equal_to<String>, EASTLAllocatorType, true>;
+        static Set s_set;
+
+        Hash m_hash;
+        View m_view;
+
+    public:
+        explicit StringId(View aView);
+        explicit StringId(CStr aCStr);
+        explicit StringId(std::nullptr_t) = delete;
+
+        explicit constexpr StringId(const StringId&) noexcept = default;
+        constexpr StringId& operator=(const StringId&) noexcept = default;
+
+        explicit constexpr StringId(StringId&&) noexcept = default;
+        constexpr StringId& operator=(StringId&&) noexcept = default;
+
+        ~StringId() = default;
+
+        [[nodiscard]]
+        Hash GetHash() const noexcept;
+        [[nodiscard]]
+        View GetView() const noexcept;
+
+        operator View() const noexcept;
+        operator CStr() const noexcept;
+
+        auto operator<=>(const StringId&) const noexcept = default;
+        bool operator==(const StringId&) const noexcept = default;
+    };
+}
+
+#endif // SOGE_SYSTEM_STRINGID_HPP

--- a/SOGE/source/SOGE/System/StringId.cpp
+++ b/SOGE/source/SOGE/System/StringId.cpp
@@ -7,7 +7,7 @@ namespace soge
 {
     StringId::Set StringId::s_set;
 
-    void StringId::InitializeAtRuntime(View aView)
+    void StringId::InitializeAtRuntime(StrView aView)
     {
         eastl::string_view view{aView.data(), aView.size()};
         m_hash = eastl::hash<decltype(view)>{}(view);
@@ -15,11 +15,11 @@ namespace soge
         auto hash = [&](const auto&) { return m_hash; };
         if (const auto iter = s_set.find_as(view, hash, eastl::equal_to()); iter != s_set.end())
         {
-            m_view = View{iter->data(), iter->size()};
+            m_view = StrView{iter->data(), iter->size()};
             return;
         }
 
         const auto iter = s_set.emplace(view).first;
-        m_view = View{iter->data(), iter->size()};
+        m_view = StrView{iter->data(), iter->size()};
     }
 }

--- a/SOGE/source/SOGE/System/StringId.cpp
+++ b/SOGE/source/SOGE/System/StringId.cpp
@@ -7,42 +7,19 @@ namespace soge
 {
     StringId::Set StringId::s_set;
 
-    StringId::StringId(const View aView) : StringId(aView.data())
+    void StringId::InitializeAtRuntime(View aView)
     {
-    }
-
-    StringId::StringId(CStr aCStr)
-    {
-        m_hash = eastl::hash<CStr>{}(aCStr);
+        eastl::string_view view{aView.data(), aView.size()};
+        m_hash = eastl::hash<decltype(view)>{}(view);
 
         auto hash = [&](const auto&) { return m_hash; };
-        if (const auto iter = s_set.find_as(aCStr, hash, eastl::equal_to()); iter != s_set.end())
+        if (const auto iter = s_set.find_as(view, hash, eastl::equal_to()); iter != s_set.end())
         {
-            m_view = {iter->data(), iter->size()};
+            m_view = View{iter->data(), iter->size()};
             return;
         }
 
-        const auto iter = s_set.emplace(aCStr).first;
-        m_view = {iter->data(), iter->size()};
-    }
-
-    auto StringId::GetHash() const noexcept -> Hash
-    {
-        return m_hash;
-    }
-
-    auto StringId::GetView() const noexcept -> View
-    {
-        return m_view;
-    }
-
-    StringId::operator View() const noexcept
-    {
-        return m_view;
-    }
-
-    StringId::operator CStr() const noexcept
-    {
-        return m_view.data();
+        const auto iter = s_set.emplace(view).first;
+        m_view = View{iter->data(), iter->size()};
     }
 }

--- a/SOGE/source/SOGE/System/StringId.cpp
+++ b/SOGE/source/SOGE/System/StringId.cpp
@@ -1,0 +1,46 @@
+#include "sogepch.hpp"
+
+#include "SOGE/System/StringId.hpp"
+
+
+namespace soge
+{
+    StringId::StringId(const View aView) : StringId(aView.data())
+    {
+    }
+
+    StringId::StringId(CStr aCStr)
+    {
+        m_hash = eastl::hash<CStr>{}(aCStr);
+
+        auto hash = [&](const auto&) { return m_hash; };
+        if (const auto iter = s_set.find_as(aCStr, hash, eastl::equal_to()); iter != s_set.end())
+        {
+            m_view = {iter->data(), iter->size()};
+            return;
+        }
+
+        const auto iter = s_set.emplace(aCStr).first;
+        m_view = {iter->data(), iter->size()};
+    }
+
+    auto StringId::GetHash() const noexcept -> Hash
+    {
+        return m_hash;
+    }
+
+    auto StringId::GetView() const noexcept -> View
+    {
+        return m_view;
+    }
+
+    StringId::operator View() const noexcept
+    {
+        return m_view;
+    }
+
+    StringId::operator CStr() const noexcept
+    {
+        return m_view.data();
+    }
+}

--- a/SOGE/source/SOGE/System/StringId.cpp
+++ b/SOGE/source/SOGE/System/StringId.cpp
@@ -5,6 +5,8 @@
 
 namespace soge
 {
+    StringId::Set StringId::s_set;
+
     StringId::StringId(const View aView) : StringId(aView.data())
     {
     }

--- a/SOGE/source/SOGE/System/StringId.cpp
+++ b/SOGE/source/SOGE/System/StringId.cpp
@@ -1,5 +1,4 @@
 #include "sogepch.hpp"
-
 #include "SOGE/System/StringId.hpp"
 
 

--- a/SOGE/source/SOGE/System/StringId.cpp
+++ b/SOGE/source/SOGE/System/StringId.cpp
@@ -7,10 +7,16 @@ namespace soge
 {
     StringId::Set StringId::s_set;
 
+    auto StringId::Hasher::operator()(const String& aStr) const noexcept -> Hash
+    {
+        const StrView view{aStr.data(), aStr.size()};
+        return operator()(view);
+    }
+
     void StringId::InitializeAtRuntime(StrView aView)
     {
         eastl::string_view view{aView.data(), aView.size()};
-        m_hash = eastl::hash<decltype(view)>{}(view);
+        m_hash = s_set.hash_function()(view);
 
         auto hash = [&](const auto&) { return m_hash; };
         if (const auto iter = s_set.find_as(view, hash, eastl::equal_to()); iter != s_set.end())


### PR DESCRIPTION
Cache dynamically allocated strings at runtime, calculate string hash at compile-time
String identifiers are compared starting from their cached hash, then the whole string compared if hashes collide

Can be useful for event system, where each event has its own string identifier