### PR TITLE
Make `StringId` hashable and thread-safe

### DIFF
--- a/SOGE/include/SOGE/System/StringId.hpp
+++ b/SOGE/include/SOGE/System/StringId.hpp
@@ -4,6 +4,8 @@
 #include <EASTL/hash_set.h>
 #include <EASTL/string.h>
 
+#include <mutex>
+
 
 namespace soge
 {
@@ -28,6 +30,7 @@ namespace soge
 
         using Set = eastl::hash_set<String, Hasher, eastl::equal_to<String>, EASTLAllocatorType, true>;
         static Set s_set;
+        static std::mutex s_mutex;
 
         void InitializeAtRuntime(StrView aView);
 

--- a/SOGE/include/SOGE/System/StringId.hpp
+++ b/SOGE/include/SOGE/System/StringId.hpp
@@ -55,6 +55,8 @@ namespace soge
         constexpr operator StrView() const noexcept;
         constexpr operator CStr() const noexcept;
 
+        constexpr void Swap(StringId& aOther) noexcept;
+
         constexpr auto operator<=>(const StringId&) const noexcept = default;
         constexpr bool operator==(const StringId&) const noexcept = default;
     };
@@ -122,6 +124,30 @@ namespace soge
     {
         return m_view.data();
     }
+
+    constexpr void StringId::Swap(StringId& aOther) noexcept
+    {
+        std::swap(m_hash, aOther.m_hash);
+        std::swap(m_view, aOther.m_view);
+    }
 }
+
+template <>
+struct std::hash<soge::StringId>
+{
+    constexpr std::size_t operator()(const soge::StringId& aStringId) const noexcept
+    {
+        return aStringId.GetHash();
+    }
+};
+
+template <>
+struct eastl::hash<soge::StringId>
+{
+    constexpr eastl_size_t operator()(const soge::StringId& aStringId) const noexcept
+    {
+        return aStringId.GetHash();
+    }
+};
 
 #endif // SOGE_SYSTEM_STRINGID_HPP

--- a/SOGE/source/SOGE/System/StringId.cpp
+++ b/SOGE/source/SOGE/System/StringId.cpp
@@ -1,10 +1,12 @@
 #include "sogepch.hpp"
+
 #include "SOGE/System/StringId.hpp"
 
 
 namespace soge
 {
     StringId::Set StringId::s_set;
+    std::mutex StringId::s_mutex;
 
     auto StringId::Hasher::operator()(const String& aStr) const noexcept -> Hash
     {
@@ -16,6 +18,9 @@ namespace soge
     {
         eastl::string_view view{aView.data(), aView.size()};
         m_hash = s_set.hash_function()(view);
+
+        // Try to be thread-safe and to not invalidate iterators
+        std::lock_guard lock{s_mutex};
 
         auto hash = [&](const auto&) { return m_hash; };
         if (const auto iter = s_set.find_as(view, hash, eastl::equal_to()); iter != s_set.end())


### PR DESCRIPTION
Tiny improvements for existing `StringId` implementation