### PR TITLE
Merge render-layers branch with dev and fix of memory leak

### DIFF
--- a/GAME/include/GAME/AppEntryPoint.hpp
+++ b/GAME/include/GAME/AppEntryPoint.hpp
@@ -4,10 +4,12 @@
 #include <SOGE/SOGE.hpp>
 
 
-namespace game
+namespace soge_game
 {
     class Game final : public soge::Engine
     {
+        using parentClass = soge::Engine;
+
     public:
         Game();
         ~Game() override;

--- a/GAME/include/GAME/Layers/MainGameLayer.hpp
+++ b/GAME/include/GAME/Layers/MainGameLayer.hpp
@@ -1,0 +1,26 @@
+#ifndef GAME_LAYERS_MAINGAMELAYER_HPP
+#define GAME_LAYERS_MAINGAMELAYER_HPP
+
+#include <SOGE/SOGE.hpp>
+
+
+namespace soge_game
+{
+    class MainGameLayer final : public soge::Layer
+    {
+    private:
+
+
+    public:
+        MainGameLayer();
+        ~MainGameLayer();
+
+        virtual void OnAttach() override;
+        virtual void OnDetach() override;
+        virtual void OnUpdate() override;
+        virtual void OnFixedUpdate(float aDeltaTime) override;
+
+    };
+}
+
+#endif // GAME_LAYERS_MAINGAMELAYER_HPP

--- a/GAME/source/GAME/AppEntryPoint.cpp
+++ b/GAME/source/GAME/AppEntryPoint.cpp
@@ -3,9 +3,10 @@
 #include <SOGE/Core/EntryPoint.hpp>
 #include <SOGE/Event/EventModule.hpp>
 #include <SOGE/Event/InputEvents.hpp>
+#include "GAME/Layers/MainGameLayer.hpp"
 
 
-namespace game
+namespace soge_game
 {
     Game::Game()
     {
@@ -13,27 +14,28 @@ namespace game
 
         auto& eventManager = GetDependencyProvider().Provide<soge::EventModule>();
 
-        eventManager.PushBack<soge::KeyPressedEvent>([](const soge::KeyPressedEvent& aEvent) {
-            SOGE_APP_INFO_LOG(R"(Key "{}" pressed {} times)", aEvent.GetKey().ToCString(), aEvent.GetRepeatCount());
-        });
-        eventManager.PushBack<soge::KeyReleasedEvent>([](const soge::KeyReleasedEvent& aEvent) {
-            SOGE_APP_INFO_LOG(R"(Key "{}" released)", aEvent.GetKey().ToCString());
-        });
+        //eventManager.PushBack<soge::KeyPressedEvent>([](const soge::KeyPressedEvent& aEvent) {
+        //    SOGE_APP_INFO_LOG(R"(Key "{}" pressed {} times)", aEvent.GetKey().ToCString(), aEvent.GetRepeatCount());
+        //});
+        //eventManager.PushBack<soge::KeyReleasedEvent>([](const soge::KeyReleasedEvent& aEvent) {
+        //    SOGE_APP_INFO_LOG(R"(Key "{}" released)", aEvent.GetKey().ToCString());
+        //});
 
-        eventManager.PushBack<soge::MouseButtonPressedEvent>([](const soge::MouseButtonPressedEvent& aEvent) {
-            const auto key = aEvent.GetKey();
-            SOGE_APP_INFO_LOG(R"(Mouse button "{}" pressed {} times)", key.ToCString(), aEvent.GetRepeatCount());
-        });
-        eventManager.PushBack<soge::MouseButtonReleasedEvent>([](const soge::MouseButtonReleasedEvent& aEvent) {
-            SOGE_APP_INFO_LOG(R"(Mouse button "{}" released)", aEvent.GetKey().ToCString());
-        });
+        //eventManager.PushBack<soge::MouseButtonPressedEvent>([](const soge::MouseButtonPressedEvent& aEvent) {
+        //    const auto key = aEvent.GetKey();
+        //    SOGE_APP_INFO_LOG(R"(Mouse button "{}" pressed {} times)", key.ToCString(), aEvent.GetRepeatCount());
+        //});
+        //eventManager.PushBack<soge::MouseButtonReleasedEvent>([](const soge::MouseButtonReleasedEvent& aEvent) {
+        //    SOGE_APP_INFO_LOG(R"(Mouse button "{}" released)", aEvent.GetKey().ToCString());
+        //});
 
-        eventManager.PushBack<soge::MouseMovedEvent>([](const soge::MouseMovedEvent& aEvent) {
-            SOGE_APP_INFO_LOG(R"(Mouse position is ({}, {}))", aEvent.GetRelativeX(), aEvent.GetRelativeY());
-        });
-        eventManager.PushBack<soge::MouseWheelEvent>([](const soge::MouseWheelEvent& aEvent) {
-            SOGE_APP_INFO_LOG(R"(Mouse wheel changed by ({}, {}))", aEvent.GetXOffset(), aEvent.GetYOffset());
-        });
+        //eventManager.PushBack<soge::MouseMovedEvent>([](const soge::MouseMovedEvent& aEvent) {
+        //    SOGE_APP_INFO_LOG(R"(Mouse position is ({}, {}))", aEvent.GetRelativeX(), aEvent.GetRelativeY());
+        //});
+        //eventManager.PushBack<soge::MouseWheelEvent>([](const soge::MouseWheelEvent& aEvent) {
+        //    SOGE_APP_INFO_LOG(R"(Mouse wheel changed by ({}, {}))", aEvent.GetXOffset(), aEvent.GetYOffset());
+        //});
+        parentClass::PushLayer(new MainGameLayer());
     }
 
     Game::~Game()
@@ -46,5 +48,5 @@ namespace game
 
 soge::Engine* soge::CreateApplication()
 {
-    return Engine::Reset<game::Game>();
+    return Engine::Reset<soge_game::Game>();
 }

--- a/GAME/source/GAME/Layers/MainGameLayer.cpp
+++ b/GAME/source/GAME/Layers/MainGameLayer.cpp
@@ -1,0 +1,35 @@
+#include "GAME/Layers/MainGameLayer.hpp"
+
+
+namespace soge_game
+{
+    MainGameLayer::MainGameLayer() : soge::Layer("MainGameLayer")
+    {
+    }
+
+    MainGameLayer::~MainGameLayer()
+    {
+    }
+
+    void MainGameLayer::OnAttach()
+    {
+        SOGE_APP_INFO_LOG("Layer {0} attached", this->m_layerName.c_str());
+    }
+
+    void MainGameLayer::OnDetach()
+    {
+    }
+
+    void MainGameLayer::OnUpdate()
+    {
+        auto inputModule = soge::Engine::GetInstance()->GetModule<soge::InputModule>();
+        if (inputModule->IsKeyPressed(soge::Keys::W))
+        {
+            SOGE_APP_INFO_LOG("Key W pressed");
+        }
+    }
+
+    void MainGameLayer::OnFixedUpdate(float aDeltaTime)
+    {
+    }
+}

--- a/SOGE/include/SOGE/Core/Engine.hpp
+++ b/SOGE/include/SOGE/Core/Engine.hpp
@@ -5,6 +5,7 @@
 #include "SOGE/DI/Container.hpp"
 #include "SOGE/System/Memory.hpp"
 #include "SOGE/System/Window.hpp"
+#include "SOGE/Core/LayerStack.hpp"
 
 
 namespace soge
@@ -20,6 +21,7 @@ namespace soge
         static UniquePtr<Engine> s_instance;
         static std::mutex s_mutex;
 
+        LayerStack m_renderLayers;
         bool m_isRunning;
         bool m_shutdownRequested;
 
@@ -72,6 +74,9 @@ namespace soge
         template <DerivedFromModule T>
         [[nodiscard]]
         T* GetModule() const;
+
+        void PushLayer(Layer* aLayer);
+        void PushOverlay(Layer* aOverlayLayer);
     };
 
     template <DerivedFromEngine T, typename... Args>

--- a/SOGE/include/SOGE/Core/Layer.hpp
+++ b/SOGE/include/SOGE/Core/Layer.hpp
@@ -1,0 +1,26 @@
+#ifndef SOGE_CORE_LAYER_HPP
+#define SOGE_CORE_LAYER_HPP
+
+
+namespace soge
+{
+    class Layer
+    {
+    protected:
+        eastl::string m_layerName;
+
+    public:
+        Layer(const eastl::string& aLayerName);
+        virtual ~Layer() = default;
+
+        virtual void OnAttach() = 0;
+        virtual void OnDetach() = 0;
+        virtual void OnUpdate() = 0;
+        virtual void OnFixedUpdate(float aDeltaTime) = 0;
+
+        const eastl::string& GetName() const;
+
+    };
+}
+
+#endif // !SOGE_CORE_LAYER_HPP

--- a/SOGE/include/SOGE/Core/LayerStack.hpp
+++ b/SOGE/include/SOGE/Core/LayerStack.hpp
@@ -1,0 +1,31 @@
+#ifndef SOGE_CORE_LAYERSTACK_HPP
+#define SOGE_CORE_LAYERSTACK_HPP
+
+#include "SOGE/Core/Layer.hpp"
+
+
+namespace soge
+{
+    class LayerStack
+    {
+    private:
+        eastl::vector<Layer*> m_layerBuffer;
+        unsigned m_layerInsertIndex = 0;
+
+    public:
+        LayerStack() = default;
+        ~LayerStack();
+
+        void PushLayer(Layer* aLayer);
+        void PushOverlay(Layer* aOverlayLayer);
+
+        void PopLayer(Layer* aLayer);
+        void PopOverlay(Layer* aOverlayLayer);
+
+        eastl::vector<Layer*>::iterator begin();
+        eastl::vector<Layer*>::iterator end();
+
+    };
+}
+
+#endif // !SOGE_CORE_LAYERSTACK_HPP

--- a/SOGE/include/SOGE/Input/Device/Keyboard.hpp
+++ b/SOGE/include/SOGE/Input/Device/Keyboard.hpp
@@ -13,8 +13,7 @@ namespace soge
         explicit Keyboard(eastl::string_view aKeyboardName);
 
         virtual void Update() = 0;
-        virtual bool IsKeyPressed(Key aKeyName) = 0;
-        virtual bool IsKeyReleased(Key aKeyName) = 0;
+
     };
 }
 

--- a/SOGE/include/SOGE/Input/Device/Mouse.hpp
+++ b/SOGE/include/SOGE/Input/Device/Mouse.hpp
@@ -13,8 +13,7 @@ namespace soge
         explicit Mouse(eastl::string_view aMouseName);
 
         virtual void Update() = 0;
-        virtual bool IsButtonPressed(Key aMouseButton) = 0;
-        virtual bool IsButtonReleased(Key aMouseButton) = 0;
+
     };
 }
 

--- a/SOGE/include/SOGE/Input/Impl/SDL/SDLInputCore.hpp
+++ b/SOGE/include/SOGE/Input/Impl/SDL/SDLInputCore.hpp
@@ -32,6 +32,14 @@ namespace soge
         void BeginUpdateInput() override;
         void EndUpdateInput() override;
         void SetPauseUpdate(bool aIsPauseNeeded) override;
+
+        bool IsKeyPressed(const Key& aKey) const override;
+        bool IsKeyReleased(const Key& aKey) const override;
+
+        Keyboard* GetKeyboard() const override;
+        Gamepad* GetGamepad() const override;
+        Mouse* GetMouse() const override;
+
     };
 
     using ImplInputCore = SDLInputCore;

--- a/SOGE/include/SOGE/Input/Impl/SDL/SDLKeyboard.hpp
+++ b/SOGE/include/SOGE/Input/Impl/SDL/SDLKeyboard.hpp
@@ -17,8 +17,7 @@ namespace soge
         explicit SDLKeyboard(SDLInputCore& aInputCore);
 
         void Update() override;
-        bool IsKeyPressed(Key aKeyName) override;
-        bool IsKeyReleased(Key aKeyName) override;
+
     };
 
     using ImplKeyboard = SDLKeyboard;

--- a/SOGE/include/SOGE/Input/Impl/SDL/SDLMouse.hpp
+++ b/SOGE/include/SOGE/Input/Impl/SDL/SDLMouse.hpp
@@ -19,8 +19,6 @@ namespace soge
 
         void Update() override;
 
-        bool IsButtonPressed(Key aMouseButton) override;
-        bool IsButtonReleased(Key aMouseButton) override;
     };
 
     using ImplMouse = SDLMouse;

--- a/SOGE/include/SOGE/Input/InputCore.hpp
+++ b/SOGE/include/SOGE/Input/InputCore.hpp
@@ -42,6 +42,14 @@ namespace soge
         virtual void BeginUpdateInput() = 0;
         virtual void EndUpdateInput() = 0;
         virtual void SetPauseUpdate(bool aIsPauseNeeded) = 0;
+
+        virtual bool IsKeyPressed(const Key& aKey) const = 0;
+        virtual bool IsKeyReleased(const Key& aKey) const = 0;
+
+        virtual Keyboard* GetKeyboard() const   = 0;
+        virtual Gamepad* GetGamepad() const     = 0;
+        virtual Mouse* GetMouse() const         = 0;
+
     };
 
     constexpr InputCore::InputCore(EventModule* aEventModule) noexcept : m_eventModule(aEventModule)

--- a/SOGE/include/SOGE/Input/InputModule.hpp
+++ b/SOGE/include/SOGE/Input/InputModule.hpp
@@ -3,12 +3,14 @@
 
 #include "SOGE/Event/EventModule.hpp"
 #include "SOGE/System/Memory.hpp"
+#include "SOGE/Input/InputCore.hpp"
+#include "SOGE/Input/Device/Keyboard.hpp"
+#include "SOGE/Input/Device/Gamepad.hpp"
+#include "SOGE/Input/Device/Mouse.hpp"
 
 
 namespace soge
 {
-    class InputCore;
-
     class InputModule : public Module
     {
     private:
@@ -24,6 +26,14 @@ namespace soge
 
         void Load(di::Container& aContainer, ModuleManager& aModuleManager) override;
         void Unload(di::Container& aContainer, ModuleManager& aModuleManager) override;
+
+        bool IsKeyPressed(const Key& aKey) const;
+        bool IsKeyReleased(const Key& aKey) const;
+
+        Keyboard* GetKeyboard() const;
+        Gamepad* GetGamepad() const;
+        Mouse* GetMouse() const;
+
     };
 }
 

--- a/SOGE/source/SOGE/Core/Engine.cpp
+++ b/SOGE/source/SOGE/Core/Engine.cpp
@@ -71,6 +71,11 @@ namespace soge
 
             const auto eventModule = GetModule<EventModule>();
             eventModule->Dispatch<UpdateEvent>(Timestep::DeltaTime());
+
+            for (auto layer : m_renderLayers)
+            {
+                layer->OnUpdate();
+            }
         }
 
         for (Module& module : m_moduleManager | std::views::reverse)
@@ -89,6 +94,18 @@ namespace soge
     void Engine::RequestShutdown()
     {
         m_shutdownRequested = true;
+    }
+
+    void Engine::PushLayer(Layer* aLayer)
+    {
+        m_renderLayers.PushLayer(aLayer);
+        aLayer->OnAttach();
+    }
+
+    void Engine::PushOverlay(Layer* aOverlayLayer)
+    {
+        m_renderLayers.PushOverlay(aOverlayLayer);
+        aOverlayLayer->OnAttach();
     }
 
     di::Container& Engine::GetDependencyContainer()

--- a/SOGE/source/SOGE/Core/Layer.cpp
+++ b/SOGE/source/SOGE/Core/Layer.cpp
@@ -1,0 +1,17 @@
+#include "sogepch.hpp"
+#include "SOGE/Core/Layer.hpp"
+
+
+namespace soge
+{
+    Layer::Layer(const eastl::string& aLayerName) : m_layerName(aLayerName)
+    {
+    }
+
+    const eastl::string& Layer::GetName() const
+    {
+        return m_layerName;
+    }
+
+
+}

--- a/SOGE/source/SOGE/Core/LayerStack.cpp
+++ b/SOGE/source/SOGE/Core/LayerStack.cpp
@@ -1,0 +1,54 @@
+#include "sogepch.hpp"
+#include "SOGE/Core/LayerStack.hpp"
+
+
+namespace soge
+{
+    LayerStack::~LayerStack()
+    {
+        for (Layer* iLayer : m_layerBuffer)
+        {
+            delete iLayer;
+        }
+    }
+
+    void LayerStack::PushLayer(Layer* aLayer)
+    {
+        m_layerBuffer.emplace(m_layerBuffer.begin() + m_layerInsertIndex, aLayer);
+        m_layerInsertIndex += 1;
+    }
+
+    void LayerStack::PushOverlay(Layer* aOverlayLayer)
+    {
+        m_layerBuffer.emplace_back(aOverlayLayer);
+    }
+
+    void LayerStack::PopLayer(Layer* aLayer)
+    {
+        auto it = eastl::find(m_layerBuffer.begin(), m_layerBuffer.end(), aLayer);
+        if (it != m_layerBuffer.end())
+        {
+            m_layerBuffer.erase(it);
+            m_layerInsertIndex -= 1;
+        }
+    }
+
+    void LayerStack::PopOverlay(Layer* aOverlayLayer)
+    {
+        auto it = eastl::find(m_layerBuffer.begin(), m_layerBuffer.end(), aOverlayLayer);
+        if (it != m_layerBuffer.end())
+        {
+            m_layerBuffer.erase(it);
+        }
+    }
+
+    eastl::vector<Layer*>::iterator LayerStack::begin()
+    {
+        return m_layerBuffer.begin();
+    }
+
+    eastl::vector<Layer*>::iterator LayerStack::end()
+    {
+        return m_layerBuffer.end();
+    }
+}

--- a/SOGE/source/SOGE/Input/Impl/SDL/SDLInputCore.cpp
+++ b/SOGE/source/SOGE/Input/Impl/SDL/SDLInputCore.cpp
@@ -68,4 +68,29 @@ namespace soge
     {
         m_isPauseUpdateRequested = aIsPauseNeeded;
     }
+
+    bool SDLInputCore::IsKeyPressed(const Key& aKey) const
+    {
+        return aKey.GetKeyState() == KeyState_KeyPressed;
+    }
+
+    bool SDLInputCore::IsKeyReleased(const Key& aKey) const
+    {
+        return aKey.GetKeyState() != KeyState_KeyPressed;
+    }
+
+    Keyboard* SDLInputCore::GetKeyboard() const
+    {
+        return m_keyboard.get();
+    }
+
+    Gamepad* SDLInputCore::GetGamepad() const
+    {
+        return m_gamepad.get();
+    }
+
+    Mouse* SDLInputCore::GetMouse() const
+    {
+        return m_mouse.get();
+    }
 }

--- a/SOGE/source/SOGE/Input/Impl/SDL/SDLKeyboard.cpp
+++ b/SOGE/source/SOGE/Input/Impl/SDL/SDLKeyboard.cpp
@@ -71,14 +71,4 @@ namespace soge
         events.DispatchQueue<KeyPressedEvent>();
         events.DispatchQueue<KeyReleasedEvent>();
     }
-
-    bool SDLKeyboard::IsKeyPressed(const Key aKeyName)
-    {
-        return aKeyName.GetKeyState() == KeyState_KeyPressed;
-    }
-
-    bool SDLKeyboard::IsKeyReleased(const Key aKeyName)
-    {
-        return aKeyName.GetKeyState() != KeyState_KeyPressed;
-    }
 }

--- a/SOGE/source/SOGE/Input/Impl/SDL/SDLMouse.cpp
+++ b/SOGE/source/SOGE/Input/Impl/SDL/SDLMouse.cpp
@@ -83,13 +83,4 @@ namespace soge
         events.DispatchQueue<MouseWheelEvent>();
     }
 
-    bool SDLMouse::IsButtonPressed(const Key aMouseButton)
-    {
-        return aMouseButton.GetKeyState() == KeyState_KeyPressed;
-    }
-
-    bool SDLMouse::IsButtonReleased(const Key aMouseButton)
-    {
-        return aMouseButton.GetKeyState() != KeyState_KeyPressed;
-    }
 }

--- a/SOGE/source/SOGE/Input/InputModule.cpp
+++ b/SOGE/source/SOGE/Input/InputModule.cpp
@@ -6,7 +6,11 @@
 
 // clang-format off
 #include SG_ABS_COMPILED_IMPL_HEADER(SOGE/Input, InputCore.hpp)
+#include SG_ABS_COMPILED_IMPL_HEADER(SOGE/Input, Keyboard.hpp)
+#include SG_ABS_COMPILED_IMPL_HEADER(SOGE/Input, Gamepad.hpp)
+#include SG_ABS_COMPILED_IMPL_HEADER(SOGE/Input, Mouse.hpp)
 // clang-format on
+
 
 
 namespace soge
@@ -23,7 +27,6 @@ namespace soge
         {
             auto update = [this](const UpdateEvent&) { this->Update(); };
             m_updateEventHandle = m_eventModule->PushBack<UpdateEvent>(update);
-
             m_inputCore = CreateUnique<ImplInputCore>(m_eventModule);
         }
 
@@ -42,8 +45,33 @@ namespace soge
         SOGE_INFO_LOG("Input module unloaded...");
     }
 
+    bool InputModule::IsKeyPressed(const Key& aKey) const
+    {
+        return m_inputCore->IsKeyPressed(aKey);
+    }
+
+    bool InputModule::IsKeyReleased(const Key& aKey) const
+    {
+        return m_inputCore->IsKeyReleased(aKey);
+    }
+
     void InputModule::Update() const
     {
         m_inputCore->BeginUpdateInput();
+    }
+
+    Keyboard* InputModule::GetKeyboard() const
+    {
+        return m_inputCore->GetKeyboard();
+    }
+
+    Gamepad* InputModule::GetGamepad() const
+    {
+        return m_inputCore->GetGamepad();
+    }
+
+    Mouse* InputModule::GetMouse() const
+    {
+        return m_inputCore->GetMouse();
     }
 }


### PR DESCRIPTION
Merged render-laerys branch to dev and provide test game layer to GAME solution. Fix memory leak in input module and moved IsKeyPressed methods from input devicies to unified InputCore IsKeyPressed method. It is useless to have this type of methods in each input device because of unified key storage.  (We was able to get mouse button state from keyboard class)