### PR TITLE
Guard against usage of engine's `GetInstance()` method in constructor

### DIFF
--- a/GAME/include/GAME/AppEntryPoint.hpp
+++ b/GAME/include/GAME/AppEntryPoint.hpp
@@ -9,7 +9,7 @@ namespace soge_game
     class Game final : public soge::Engine
     {
     public:
-        explicit Game(AccessTag);
+        explicit Game(AccessTag&& aTag);
 
         Game(const Game&) = delete;
         Game& operator=(const Game&) = delete;

--- a/GAME/source/GAME/AppEntryPoint.cpp
+++ b/GAME/source/GAME/AppEntryPoint.cpp
@@ -36,6 +36,8 @@ namespace soge_game
         // eventManager.PushBack<soge::MouseWheelEvent>([](const soge::MouseWheelEvent& aEvent) {
         //     SOGE_APP_INFO_LOG(R"(Mouse wheel changed by ({}, {}))", aEvent.GetXOffset(), aEvent.GetYOffset());
         // });
+
+        PushLayer(new MainGameLayer());
     }
 
     Game::~Game()
@@ -47,7 +49,6 @@ namespace soge_game
 
     void Game::Load(AccessTag)
     {
-        PushLayer(new MainGameLayer());
     }
 }
 

--- a/GAME/source/GAME/AppEntryPoint.cpp
+++ b/GAME/source/GAME/AppEntryPoint.cpp
@@ -36,8 +36,6 @@ namespace soge_game
         // eventManager.PushBack<soge::MouseWheelEvent>([](const soge::MouseWheelEvent& aEvent) {
         //     SOGE_APP_INFO_LOG(R"(Mouse wheel changed by ({}, {}))", aEvent.GetXOffset(), aEvent.GetYOffset());
         // });
-
-        PushLayer(new MainGameLayer());
     }
 
     Game::~Game()
@@ -49,6 +47,7 @@ namespace soge_game
 
     void Game::Load(AccessTag)
     {
+        PushLayer(new MainGameLayer());
     }
 }
 

--- a/GAME/source/GAME/AppEntryPoint.cpp
+++ b/GAME/source/GAME/AppEntryPoint.cpp
@@ -9,7 +9,7 @@
 
 namespace soge_game
 {
-    Game::Game(const AccessTag aTag) : Engine(aTag)
+    Game::Game(AccessTag&& aTag) : Engine(std::move(aTag))
     {
         SOGE_APP_INFO_LOG("Initialize game...");
 

--- a/GAME/source/GAME/Layers/MainGameLayer.cpp
+++ b/GAME/source/GAME/Layers/MainGameLayer.cpp
@@ -5,6 +5,7 @@ namespace soge_game
 {
     MainGameLayer::MainGameLayer() : Layer("MainGameLayer")
     {
+        SOGE_INFO_LOG("Global engine instance pointer is {}", static_cast<void*>(soge::Engine::GetInstance()));
     }
 
     void MainGameLayer::OnAttach()

--- a/SOGE/include/SOGE/Core/Engine.hpp
+++ b/SOGE/include/SOGE/Core/Engine.hpp
@@ -39,9 +39,18 @@ namespace soge
             friend Engine;
 
             explicit AccessTag() = default;
+
+        public:
+            explicit AccessTag(const AccessTag&) = delete;
+            AccessTag& operator=(const AccessTag&) = delete;
+
+            explicit AccessTag(AccessTag&&) noexcept = default;
+            AccessTag& operator=(AccessTag&&) noexcept = default;
+
+            ~AccessTag() = default;
         };
 
-        explicit Engine(AccessTag);
+        explicit Engine(AccessTag&& aTag);
 
         virtual void Load(AccessTag);
         virtual void Unload(AccessTag);
@@ -90,9 +99,8 @@ namespace soge
     template <DerivedFromEngine T, typename... Args>
     T* Engine::Reset(Args&&... args)
     {
-        constexpr AccessTag tag;
         // Replicating `make_unique` here because the constructor is protected
-        UniquePtr<T> newInstance(new T(tag, std::forward<Args>(args)...));
+        UniquePtr<T> newInstance(new T(AccessTag{}, std::forward<Args>(args)...));
         // Save pointer to `T` to avoid dynamic cast later
         T* pNewInstance = newInstance.get();
 

--- a/SOGE/source/SOGE/Core/Engine.cpp
+++ b/SOGE/source/SOGE/Core/Engine.cpp
@@ -16,6 +16,7 @@ namespace soge
 {
     UniquePtr<Engine> Engine::s_instance(nullptr);
     std::mutex Engine::s_mutex;
+    thread_local std::atomic_bool Engine::s_mutexLocked;
 
     Engine* Engine::GetInstance()
     {
@@ -26,7 +27,10 @@ namespace soge
         }
 
         // Safe but slow path: initialize with default class if empty
+        AssertMutexIsNotLocked();
         std::lock_guard lock(s_mutex);
+        MutexLockedGuard mutexLockedGuard;
+
         // Additional check to ensure we are creating new instance exactly once
         if (s_instance == nullptr)
         {
@@ -34,6 +38,27 @@ namespace soge
             s_instance = UniquePtr<Engine>(new Engine(AccessTag{}));
         }
         return s_instance.get();
+    }
+
+    Engine::MutexLockedGuard::MutexLockedGuard() noexcept
+    {
+        s_mutexLocked = true;
+    }
+
+    Engine::MutexLockedGuard::~MutexLockedGuard() noexcept
+    {
+        s_mutexLocked = false;
+    }
+
+    void Engine::AssertMutexIsNotLocked()
+    {
+        if (!s_mutexLocked.load())
+        {
+            return;
+        }
+
+        SOGE_ERROR_LOG("Engine mutex is already locked by the current thread!");
+        std::exit(EXIT_FAILURE); // NOLINT(concurrency-mt-unsafe)
     }
 
     Engine::Engine([[maybe_unused]] AccessTag&& aTag) : m_isRunning(false), m_shutdownRequested(false)
@@ -66,7 +91,9 @@ namespace soge
         }
 
         // Prevent users from resetting engine while it is running
+        AssertMutexIsNotLocked();
         std::lock_guard lock(s_mutex);
+        MutexLockedGuard mutexLockedGuard;
 
         m_isRunning = true;
         for (Module& module : m_moduleManager)


### PR DESCRIPTION
...and from situations similar to one mentioned in the title